### PR TITLE
Fix: twitterへの投稿方法を修正

### DIFF
--- a/app/controllers/twitter_controller.rb
+++ b/app/controllers/twitter_controller.rb
@@ -21,8 +21,8 @@ class TwitterController < ApplicationController
     @twitter = Twitter::REST::Client.new do |config|
       config.consumer_key        = ENV['twitter_api_key']
       config.consumer_secret     = ENV['twitter_api_secret']
-      config.access_token        = ENV['twitter_access_token']
-      config.access_token_secret = ENV['twitter_access_token_secret']
+      config.access_token = session[:access_token]
+      config.access_token_secret = session[:access_token_secret]
     end
   end
 

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -16,6 +16,10 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
     @user = User.find_for_oauth(request.env['omniauth.auth'])
 
+    auth = request.env['omniauth.auth']
+    session[:access_token] = auth.credentials.token
+    session[:access_token_secret] = auth.credentials.secret
+
     if @user.persisted?
       logger.info('persisted true')
       flash[:notice] = I18n.t('devise.omniauth_callbacks.success', kind: provider.capitalize)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,6 +6,11 @@ class UsersController < ApplicationController
   skip_before_action :verify_authenticity_token
   def index; end
 
+  def rank_share
+    url = 'https://twitter.com/share?url=https://radio-sort.xyz&amp;text=' + share_contnets
+    redirect_to url
+  end
+
   def show
     @likes = @user.likes.rank(:row_order)
   end
@@ -30,5 +35,15 @@ class UsersController < ApplicationController
     @q = User.ransack(params[:q])
     @q.sorts = 'id asc' if @q.sorts.empty?
     @users = @q.result(distinct: true).page(params[:page])
+  end
+
+  def share_contnets
+    @likes = current_user.likes.rank(:row_order)
+    tweet_content = '%23ラジオソート%0a%0a'
+
+    @likes.first(5).each_with_index do |like, i|
+      tweet_content += "#{i + 1}位: #{like.radio.title}%0a"
+    end
+    tweet_content += '%0a'
   end
 end

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -3,12 +3,19 @@
 .row
   .col.s12.m9.l9
     - if @user == current_user && @user.likes.present?
-      br
-      = link_to confirm_path, method: :post do
-        = image_tag 'number/Twitter3.png', width: "4%", style: "vertical-align:middle; margin-left:10px"
-        '
-        |Twitterで共有する
-      br
+      - if current_user.uid.present?
+        br
+        = link_to confirm_path, method: :post do
+          = image_tag 'number/Twitter3.png', width: "4%", style: "vertical-align:middle; margin-left:10px"
+          '
+          |Twitterで共有する
+        br
+      - else
+        br
+        = link_to user_rank_share_path(@user), :onclick => "window.open(this.href,'hoge', 'height=400, width=600');return false;" do
+          = image_tag 'number/Twitter3.png', width: "4%", style: "vertical-align:middle; margin-left:10px"
+          '
+          |Twitterで共有する
     - if @user.likes.blank?
       .collection.usercomment
         = link_to radios_path, class: 'a collection-item collection-header blue-grey lighten-5 center' do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
 
   resources :users, only: %i[index show] do
     get :relations_index
+    get :rank_share
   end
 
   resources :likes do


### PR DESCRIPTION
いかなる状況でも自身のtwitterアカウントで投稿してしまう状態を修正。

- access_token / access_token_secret をログイン時にセッションに保存
- 非twitterログイン時はシェアボタンを使用

closes #62 

